### PR TITLE
make a new page for 2019 sponsors

### DIFF
--- a/_pages/2018/sponsors.md
+++ b/_pages/2018/sponsors.md
@@ -1,0 +1,91 @@
+---
+layout: page
+permalink: /2018/sponsors/
+---
+
+<div class="pretty-links">
+
+# 2018 Sponsors
+
+[![](/assets/img/sponsors/stripe.png)](http://grnh.se/4cxbw61)
+
+[Stripe](https://stripe.com/) is a software platform for starting and running internet businesses. Hundreds of thousands of businesses—including Lyft, Kickstarter, Salesforce, Shopify, Facebook, Slack, and UNICEF—rely on Stripe’s software tools to accept payments, expand globally, and create new revenue streams. Stripe has been at the forefront of expanding internet commerce, powering new business models, and supporting the latest platforms, from marketplaces to mobile commerce sites.
+<br/><br/>
+We believe that growing the GDP of the internet is a problem rooted in code and design, not finance. Stripe is built for developers, makers, and creators. We work on solving the hard technical problems necessary to build global economic infrastructure—from designing highly reliable systems to developing advanced machine learning algorithms to prevent fraud. Join us!
+
+
+![](/assets/img/sponsors/sortable.png)
+
+[Sortable](https://sortable.com/) helps publishers unify demand partners, data, and tools. Their ultimate goal is to simplify the complexities of publishing operations while generating more revenue for our publisher partners.
+
+![](/assets/img/sponsors/square.png)
+
+[Square](https://squareup.com/) empowers business owners to accept payments, help restaurants set up a delivery option, and provide capital to allow businesses to grow. We make the tough choice to give people access to their funds faster.  We built the Cash App to provide a quick and easy solution to participate in the economy. To level the playing field. To make the system more fair. That's how we started and that's why we're here.
+<br/><br/>
+One of the greatest issues facing our civilization is economic inequality, and we have a role in addressing it. We believe everyone should be able to participate and thrive in the economy. So we build accessible tools that shorten the distance between having an idea and making a living from it. Tools that make people feel good and inspire them to do good.
+
+![](/assets/img/sponsors/asana.png)
+
+[Asana](https://asana.com) has a big mission and an even bigger opportunity: to empower all teams to do great things together. It’s free & simple to get started, and powerful enough to run your entire business. Teams in the world’s fastest growing companies track their work and achieve their goals with Asana. And we’re not stopping there. Our team of peers is growing rapidly and we're tackling new challenges daily. We'd ♥️️ your help, join us at [asana.com/careers](https://asana.com/careers).
+
+![](/assets/img/sponsors/Adzerk.png)
+
+[Adzerk](https://adzerk.com/) provides a suite of APIs for building your own customized ad server. While ad servers are a must for publishers, 3rd-party solutions don’t offer flexibility, and building your own could take years and cost millions. Fortunately, with Adzerk's APIs, you have the infrastructure tools to build your own ad server in just weeks. Adzerk customers include innovative and tech-savvy brands such as reddit, Imgur, Cox Media, Entravision, Wattpad, Atom Tickets, and more.
+
+![](/assets/img/sponsors/funnelcake.png)
+
+[FunnelCake](https://getfunnelcake.com/) is a RevOps platform that tells you how to beat your growth targets. Connect Salesforce and FunnelCake to drive your RevOps engine. FunnelCake identifies gaps between your pipeline and your growth goals, then guides Marketing, Sales, and Customer Success with actionable insights – like how many leads you need to create, when you need to hire Sales reps to hit growth targets, and red flag alerts on pipeline.
+
+![](/assets/img/sponsors/zenreach.png)
+
+[Zenreach](https://www.zenreach.com/) was created to solve one of the most important problems in the modern economy—the majority of our time is being spent online, yet over 93% of purchasing still happens offline — and there is no link between the two systems. Brick-and-mortar merchants are working decades behind their online counterparts without essential data and tools. We created Zenreach to give them the same level of technology and transparency that anyone operating online has come to expect.
+
+![](/assets/img/sponsors/shopify.png)
+
+[Shopify](https://www.shopify.com/) is a leading cloud-based, multichannel commerce platform designed for small and medium-sized businesses. Merchants can use the software to design, set up, and manage their stores across multiple sales channels, including web, mobile, social media, marketplaces, brick-and-mortar locations, and pop-up shops. The Shopify platform was engineered for reliability and scale.
+
+![](/assets/img/sponsors/no_starch_press.jpg)
+
+The finest in geek entertainment. Thank you [No Starch Press](https://www.nostarch.com/) for sending us a collection of popular technical books, vouchers for free ebooks, and miscellaneous No Starch merch to hand out at StarCon!
+
+[![](/assets/img/sponsors/microsoft.png)](https://www.microsoft.com/en-us/about/default.aspx)
+
+We believe in what people make possible. Our mission is to empower every person and every organization on the planet to achieve more.
+
+![](/assets/img/sponsors/scs.png)
+
+The David R. Cheriton School of Computer Science brings together over 80 faculty, 40 staff and 2000 students at the undergraduate and graduate levels. The School has its origin in the Department of Applied Analysis and Computer Science, founded in 1967, and has grown to become the largest academic computer science research centre in Canada, ranking 10th in North America and 24th in the world.
+
+
+![](/assets/img/sponsors/MEF.png)
+
+The [Mathematics Endowment Fund](https://uwaterloo.ca/math-endowment-fund/about) (MEF) is an income-generating fund that finances projects for the academic betterment of mathematics undergraduate students at the University of Waterloo. Members of the StarCon organizing committee have used MEF funding for previous projects on the Women in CS committee and for attending conferences. We're very grateful for their support. If you are a Waterloo math student and not in town for StarCon, we recommend reaching out to them for travel funding!
+
+![](/assets/img/sponsors/wics.png)
+
+[Women in Computer Science](https://cs.uwaterloo.ca/wics) (WICS) is dedicated to promoting women who are interested in studying computer science and who seek to pursue careers in computing.
+
+<hr>
+
+<hr>
+
+
+## Why You Should Sponsor Us
+
+Do you want to sponsor us too? We're currently looking for sponsors!
+
+By sponsoring StarCon, you will empower diverse perspectives in technology and contribute towards creating a community grounded in learning. You will also have the opportunity to actively interact with a group of people keenly interested in technology. You can leverage this opportunity to market your brand and product, create awareness of your core values and philosophies, share what it’s like to be a part of your organization, talk about your plans for the future, and recruit candidates for open positions.
+
+In addition to this, you will be supporting our mission of providing people with a community in which they can share their excitement and ideas with others. You will help us meet our goals to keep this event affordable, encourage students to speak and attend, provide an accessible venue, make sure our attendees are well fed, and give them some swag to remember us by!
+
+To read more about StarCon and our sponsorship packages, check out our [prospectus](/prospectus).
+
+If you're interested in sponsoring us, or have any questions about sponsorship,
+email us!
+
+## Contact
+
+Arshia Mufti, Director of Sponsorship:
+[amufti16@gmail.com](mailto:amufti16@gmail.com)
+
+</div>

--- a/_pages/sponsors.md
+++ b/_pages/sponsors.md
@@ -5,65 +5,15 @@ permalink: /sponsors/
 
 <div class="pretty-links">
 
-# 2018 Sponsors
+# 2019 Sponsors
 
-[![](/assets/img/sponsors/stripe.png)](http://grnh.se/4cxbw61)
+<br/>
 
-[Stripe](https://stripe.com/) is a software platform for starting and running internet businesses. Hundreds of thousands of businesses—including Lyft, Kickstarter, Salesforce, Shopify, Facebook, Slack, and UNICEF—rely on Stripe’s software tools to accept payments, expand globally, and create new revenue streams. Stripe has been at the forefront of expanding internet commerce, powering new business models, and supporting the latest platforms, from marketplaces to mobile commerce sites.
-<br/><br/>
-We believe that growing the GDP of the internet is a problem rooted in code and design, not finance. Stripe is built for developers, makers, and creators. We work on solving the hard technical problems necessary to build global economic infrastructure—from designing highly reliable systems to developing advanced machine learning algorithms to prevent fraud. Join us!
+We'll start announcing our 2019 sponsors soon.
 
+Want to join the list? Read more below!
 
-![](/assets/img/sponsors/sortable.png)
-
-[Sortable](https://sortable.com/) helps publishers unify demand partners, data, and tools. Their ultimate goal is to simplify the complexities of publishing operations while generating more revenue for our publisher partners.
-
-![](/assets/img/sponsors/square.png)
-
-[Square](https://squareup.com/) empowers business owners to accept payments, help restaurants set up a delivery option, and provide capital to allow businesses to grow. We make the tough choice to give people access to their funds faster.  We built the Cash App to provide a quick and easy solution to participate in the economy. To level the playing field. To make the system more fair. That's how we started and that's why we're here.
-<br/><br/>
-One of the greatest issues facing our civilization is economic inequality, and we have a role in addressing it. We believe everyone should be able to participate and thrive in the economy. So we build accessible tools that shorten the distance between having an idea and making a living from it. Tools that make people feel good and inspire them to do good.
-
-![](/assets/img/sponsors/asana.png)
-
-[Asana](https://asana.com) has a big mission and an even bigger opportunity: to empower all teams to do great things together. It’s free & simple to get started, and powerful enough to run your entire business. Teams in the world’s fastest growing companies track their work and achieve their goals with Asana. And we’re not stopping there. Our team of peers is growing rapidly and we're tackling new challenges daily. We'd ♥️️ your help, join us at [asana.com/careers](https://asana.com/careers).
-
-![](/assets/img/sponsors/Adzerk.png)
-
-[Adzerk](https://adzerk.com/) provides a suite of APIs for building your own customized ad server. While ad servers are a must for publishers, 3rd-party solutions don’t offer flexibility, and building your own could take years and cost millions. Fortunately, with Adzerk's APIs, you have the infrastructure tools to build your own ad server in just weeks. Adzerk customers include innovative and tech-savvy brands such as reddit, Imgur, Cox Media, Entravision, Wattpad, Atom Tickets, and more.
-
-![](/assets/img/sponsors/funnelcake.png)
-
-[FunnelCake](https://getfunnelcake.com/) is a RevOps platform that tells you how to beat your growth targets. Connect Salesforce and FunnelCake to drive your RevOps engine. FunnelCake identifies gaps between your pipeline and your growth goals, then guides Marketing, Sales, and Customer Success with actionable insights – like how many leads you need to create, when you need to hire Sales reps to hit growth targets, and red flag alerts on pipeline.
-
-![](/assets/img/sponsors/zenreach.png)
-
-[Zenreach](https://www.zenreach.com/) was created to solve one of the most important problems in the modern economy—the majority of our time is being spent online, yet over 93% of purchasing still happens offline — and there is no link between the two systems. Brick-and-mortar merchants are working decades behind their online counterparts without essential data and tools. We created Zenreach to give them the same level of technology and transparency that anyone operating online has come to expect.
-
-![](/assets/img/sponsors/shopify.png)
-
-[Shopify](https://www.shopify.com/) is a leading cloud-based, multichannel commerce platform designed for small and medium-sized businesses. Merchants can use the software to design, set up, and manage their stores across multiple sales channels, including web, mobile, social media, marketplaces, brick-and-mortar locations, and pop-up shops. The Shopify platform was engineered for reliability and scale.
-
-![](/assets/img/sponsors/no_starch_press.jpg)
-
-The finest in geek entertainment. Thank you [No Starch Press](https://www.nostarch.com/) for sending us a collection of popular technical books, vouchers for free ebooks, and miscellaneous No Starch merch to hand out at StarCon!
-
-[![](/assets/img/sponsors/microsoft.png)](https://www.microsoft.com/en-us/about/default.aspx)
-
-We believe in what people make possible. Our mission is to empower every person and every organization on the planet to achieve more.
-
-![](/assets/img/sponsors/scs.png)
-
-The David R. Cheriton School of Computer Science brings together over 80 faculty, 40 staff and 2000 students at the undergraduate and graduate levels. The School has its origin in the Department of Applied Analysis and Computer Science, founded in 1967, and has grown to become the largest academic computer science research centre in Canada, ranking 10th in North America and 24th in the world.
-
-
-![](/assets/img/sponsors/MEF.png)
-
-The [Mathematics Endowment Fund](https://uwaterloo.ca/math-endowment-fund/about) (MEF) is an income-generating fund that finances projects for the academic betterment of mathematics undergraduate students at the University of Waterloo. Members of the StarCon organizing committee have used MEF funding for previous projects on the Women in CS committee and for attending conferences. We're very grateful for their support. If you are a Waterloo math student and not in town for StarCon, we recommend reaching out to them for travel funding!
-
-![](/assets/img/sponsors/wics.png)
-
-[Women in Computer Science](https://cs.uwaterloo.ca/wics) (WICS) is dedicated to promoting women who are interested in studying computer science and who seek to pursue careers in computing.
+Learn more about our 2018 sponsors [here](/2018/sponsors).
 
 <hr>
 


### PR DESCRIPTION
this is only the beginning of archiving, but I think having a new sponsor page for advertising sponsors would be good!

as we start updating speaker stuff and cfp, we should more properly archive the whole old website and update all the relevant links and stuff