### PR TITLE
Updates CFP page for 2018 CFP

### DIFF
--- a/_pages/cfp.md
+++ b/_pages/cfp.md
@@ -5,22 +5,19 @@ subtitle: StarCon 2018 Call for Proposals
 permalink: /cfp/
 ---
 
-**The call for talk proposals for StarCon 2018 is now closed.**
 
-## Original call for proposals (for posterity)
-
-We’re excited to announce that StarCon is having its first Call for Proposals (CFP)! We’re looking for folks who have a passion for technology, learning and sharing to submit talks about their favourite piece(s) of technology.
+We’re excited to announce that StarCon is having its second Call for Proposals (CFP)! We’re looking for folks who have a passion for technology, learning and sharing to submit talks about their favourite piece(s) of technology.
 
 We’ve named this conference StarCon (\*Con) for a reason. We want to represent many different people and topics in technology, just like how the wildcard asterisk symbol represents any character or symbol.
 
 We want to hear about anything technology related, from projects to bugs to something interesting you’ve learned.
 
-We really want to hear from you if:
+We **really** want to hear from you if:
 - You are a first time speaker.
 - You are a member of an underrepresented group in technology.
 - You’ve hesitated to apply to speak at conferences  in the past because you think that you have nothing to contribute or you feel less qualified than your peers.
 
-**[Submit Your Talk Here](https://goo.gl/forms/ooTbAnAtcJmneZSE2)**
+**[Submit Your Talk Here](https://easychair.org/conferences/?conf=starcon2019)**
 
 ## Basic Information
 
@@ -30,27 +27,19 @@ We really want to hear from you if:
 
 ## Important Dates
 
-CFP Opens: August 14 2017, 10:00AM EST
+CFP Opens: August 1 2018, 10:00AM EST
 
-CFP Closes: September 17 2017, 11:59PM EST
+CFP Closes: September 1 2018, 11:59PM EST
 
-Acceptances/Rejections Sent: October 31 2017
+Acceptances/Rejections Sent: October 1 2018 
 
-## Selection Process
+## How To Submit Your Talk
 
-Here is how our selection process works:
+This year we're using EasyChair to manage our CFP process. If you do not already have an EasyChair account, you need to [create an account](https://easychair.org/account/signup.cgi?conf=starcon2019). During account creation, EasyChair will ask for personal information including your organization, country, and personal web page. If you are a student, you can use your school in place of organization. Use the personal web page section to let us know where we can find you on the internet. This could be a personal web site, twitter, linkedin, etc (whatever you're comfortable sharing). _Note that this information will be anonymized during the review process._
 
-1. When you submit your proposal, your name and contact information will be anonymized.
-2. Once the CFP closes, proposals are distributed among the members of our CFP Review Committee.
-3. The review process has two stages:
+You can view EasyChair's Terms of Service and Privacy Policy [here](https://www.easychair.org/terms.cgi).
 
-	a) The CFP Review Committee members review their assigned proposals individually, and give the proposal a score.
-
-	b) The CFP Review Committee gathers to discuss the proposals and to make a list of potential accepted talks.
-4. Speaker names and contact information are de-anonymized and there is a period for the CFP Review Committee to confirm their choices of proposals to accept.
-5. All applicants are informed if their talk was accepted or rejected.
-
-## Guidelines
+### Guidelines
 
 We ask for three things other than your basic information: An abstract, a timeline, and a short answer to a question. Please keep in mind that these guidelines are things you must cover in your proposal, but are not limited to.
 
@@ -59,10 +48,10 @@ We ask for three things other than your basic information: An abstract, a timeli
 **Do not include any personally identifying information in your abstract, timeline or answer to the short answer question. This includes:**
 - **Your name**
 - **Where you work/go to school**
-- **Any relation to the StarCon organizers or members of the CFP Review Committee**
+- **Any relation to the StarCon organizers or members of the StarCon Program Committee**
 - **Your gender, ethnicity, sexual orientation, religion (or lack of) etc**
 
-### Abstract
+#### Abstract
 
 In this section, we’re looking for a brief summary of your talk. The reviewers will use this to determine the relevance of the topic and to get a feel for what the talk will cover.
 
@@ -77,7 +66,7 @@ Example:
 
 _Maintaining good relationships with your co-workers is vital to both personal and organizational development. In my talk "asdfhgj: How Stepping on Keyboards Can Improve Your Team"  I will cover the basics of the technique and how it can improve relationships with your peers, or your human roommates. Stepping on Keyboards (SoK) is a relatively unknown team-building technique among humans, however it is very well known among the feline community. SoK prioritizes getting in the way of a human while they are sitting at their computer, preferably typing, and demanding that they pay attention to you, thus improving communication skills among any human-cat team. The audience will be introduced to the topic, learn several of the common techniques and see a live demo. I believe that this technique is an untapped resource for most teams and that it has the potential to have a large impact on team-building and team development for small to large scale organizations._
 
-### Timeline
+#### Timeline
 
 The purpose of this is to get a feel for the pacing of your talk. Unlike the abstract, this will not be posted on the website if your talk is selected.
 
@@ -98,18 +87,32 @@ Example:
 	- _The Future of SoK_
 	- _How you can incorporate SoK into your team_
 
-### Short Answer Question: Why do you want to talk at StarCon?
+#### Short Answer Question: Why do you want to talk at StarCon?
 
 The point of this is to get to know you better! Think of this as a friendly conversation rather than an elevator pitch.
 
 Your answer should:
- - Be approximately 300 words
+ - Be approximately 200 words
+
+## Selection Process
+
+Here is how our selection process works:
+
+1. When you submit your proposal, your name and contact information will be anonymized.
+2. Once the CFP closes, proposals are distributed among the members of our Program Committee.
+3. The review process has two stages:
+
+	a) The CFP Review Committee members review their assigned proposals individually, and give the proposal a score.
+
+	b) The CFP Review Committee gathers to discuss the proposals and to make a list of potential accepted talks.
+4. Speaker names and contact information are de-anonymized and there is a period for the CFP Review Committee to confirm their choices of proposals to accept.
+5. All applicants are informed if their talk was accepted or rejected.
 
 ## Accepted Speaker Compensation
 
 We believe in compensating our speakers. If accepted you will receive:
 
-- 70 CAD. We are in the process of determining the best way to deliver this. It will either be via cheque or gift card.
+- 100 CAD
 - Full access to the conference venue and events.
 - Breakfast and lunch for both days of the conference.
 
@@ -120,10 +123,7 @@ We will do our best to provide travel funding for speakers coming from outside t
 
 ## Creative Commons
 
-Should your talk be accepted, it is our intention to record (audio/video), transcribe, and publish your talk on the internet for free under a [CC BY-ND](https://creativecommons.org/licenses/by-nd/2.0/ca/) license. So we ask that you make any materials used available under a CC BY-ND creative commons license.  You will retain full ownership of any materials used in your talk (slide deck, handouts etc).
-
-If you are uncomfortable with this, please email our Speaker & CFP Coordinator Anna Lorimer at [uwstarconcfp@gmail.com](mailto:uwstarconcfp@gmail.com) to discuss alternatives.
-
+Should your talk be accepted, you can opt-in to have your talk to recorded (audio/video), transcribed, and published under a [CC BY-ND](https://creativecommons.org/licenses/by-nd/2.0/ca/) license. So we ask that you make any materials used available under a CC BY-ND creative commons license.  You will retain full ownership of any materials used in your talk (slide deck, handouts etc).
 
 ## FAQ
 
@@ -139,13 +139,13 @@ Yes, but please don’t submit more than two.  If both your talks are accepted, 
 
 Yes! We’d love to have you. Please note that you’ll be responsible for obtaining a visa, should you need one, to enter Canada.
 
-
 **Can I get feedback on my application?**
 
 Unfortunately, we will not be able to offer this. We simply don’t have the resources to offer this to everyone at a quality we feel is appropriate.
 
 **I have other questions! Who do I talk to?**
 
-Our Speaker & CFP Coordinator is Anna Lorimer, send any and all CFP-related questions to her at [uwstarconcfp@gmail.com](mailto:uwstarconcfp@gmail.com).
+Plese send any and all CFP-related questions to our Speakers Team at [starcon-speakers@googlegroups.com](mailto:starcon-speakers@@googlegroups.com).
+
 
 

--- a/_pages/cfp.md
+++ b/_pages/cfp.md
@@ -17,7 +17,9 @@ We **really** want to hear from you if:
 - You are a member of an underrepresented group in technology.
 - You’ve hesitated to apply to speak at conferences  in the past because you think that you have nothing to contribute or you feel less qualified than your peers.
 
-**[Submit Your Talk Here](https://easychair.org/conferences/?conf=starcon2019)**
+**Before submitting your talk, make sure you've read the guidelines below.**
+
+**[Submit Your Talk Here](https://easychair.org/conferences/?conf=starcon2019)** (The form will open on August 1st)
 
 ## Basic Information
 
@@ -35,7 +37,7 @@ Acceptances/Rejections Sent: October 1 2018
 
 ## How To Submit Your Talk
 
-This year we're using EasyChair to manage our CFP process. If you do not already have an EasyChair account, you need to [create an account](https://easychair.org/account/signup.cgi?conf=starcon2019). During account creation, EasyChair will ask for personal information including your organization, country, and personal web page. If you are a student, you can use your school in place of organization. Use the personal web page section to let us know where we can find you on the internet. This could be a personal web site, twitter, linkedin, etc (whatever you're comfortable sharing). _Note that this information will be anonymized during the review process._
+This year we're using EasyChair to manage our CFP process. If you do not already have an EasyChair account, you need to [create an account](https://easychair.org/account/signup.cgi?conf=starcon2019). During account creation, EasyChair will ask for personal information including your organization, country, and personal web page. If you are a student, you can use your school in place of organization. Use the personal web page section to let us know where we can find you on the internet. This could be a personal web site, twitter, linkedin, etc (whatever you're comfortable sharing). _Note that this information will be anonymized and not visible to the program committee during the review process._
 
 You can view EasyChair's Terms of Service and Privacy Policy [here](https://www.easychair.org/terms.cgi).
 
@@ -50,6 +52,8 @@ We ask for three things other than your basic information: An abstract, a timeli
 - **Where you work/go to school**
 - **Any relation to the StarCon organizers or members of the StarCon Program Committee**
 - **Your gender, ethnicity, sexual orientation, religion (or lack of) etc**
+
+**Including personally identifiable information in your submission may result in disqualification if the Speakers Team is unable to anonymize is sufficiently**
 
 #### Abstract
 
@@ -145,7 +149,7 @@ Unfortunately, we will not be able to offer this. We simply don’t have the res
 
 **I have other questions! Who do I talk to?**
 
-Plese send any and all CFP-related questions to our Speakers Team at [starcon-speakers@googlegroups.com](mailto:starcon-speakers@@googlegroups.com).
+Plese send any and all CFP-related questions to our Speakers Team at [starcon-speakers@googlegroups.com](mailto:starcon-speakers@googlegroups.com).
 
 
 


### PR DESCRIPTION
Changes from last year: 

- Adds information about submitting talks to EasyChair, including EasyChair's ToS and PP
- Updates all the dates
- Moves the guidelines further up the page, hopefully helps mitigate confusion around the timeline